### PR TITLE
Fix build for VS2010...?

### DIFF
--- a/gslAsubApp/src/line_of_best_fit.c
+++ b/gslAsubApp/src/line_of_best_fit.c
@@ -26,10 +26,10 @@
  */
 static long line_of_best_fit(aSubRecord *prec)
 {
+    int status;
+
     // Disable default error handler for GSL as it terminates the process. Check return values instead.
     gsl_set_error_handler_off();
-    
-    int status;
     
     if (prec->fta != menuFtypeDOUBLE || prec->ftb != menuFtypeDOUBLE)
     {


### PR DESCRIPTION
I believe VS2010 may be a bit more picky than 2017 about mixed code and declarations - I think it needs all variables declared first.

The previous code failed on the build server (but not on dev machines)